### PR TITLE
Add local developer diary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>開発者日記</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      text-align: center;
+      background-color: #f5f5f5;
+      margin: 0;
+      padding: 1em;
+    }
+    textarea {
+      width: 80%;
+      max-width: 500px;
+      height: 100px;
+    }
+    #diaryList {
+      margin-top: 1em;
+      text-align: left;
+      max-width: 500px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .entry {
+      background: #fff;
+      padding: 0.5em;
+      margin-bottom: 0.5em;
+      border-radius: 4px;
+      box-shadow: 0 0 5px rgba(0,0,0,0.1);
+    }
+    .date {
+      font-size: 0.8em;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <h1>開発者日記</h1>
+  <textarea id="diaryInput" placeholder="今日の作業メモ"></textarea><br>
+  <button id="addBtn">追加</button>
+  <div id="diaryList"></div>
+
+  <script>
+    function loadDiary() {
+      const list = document.getElementById('diaryList');
+      list.innerHTML = '';
+      const entries = JSON.parse(localStorage.getItem('developerDiary') || '[]');
+      entries.forEach(entry => {
+        const div = document.createElement('div');
+        div.className = 'entry';
+        const date = document.createElement('div');
+        date.className = 'date';
+        date.textContent = entry.date;
+        const text = document.createElement('div');
+        text.textContent = entry.text;
+        div.appendChild(date);
+        div.appendChild(text);
+        list.appendChild(div);
+      });
+    }
+
+    document.getElementById('addBtn').addEventListener('click', () => {
+      const textarea = document.getElementById('diaryInput');
+      const text = textarea.value.trim();
+      if (text === '') return;
+      const entries = JSON.parse(localStorage.getItem('developerDiary') || '[]');
+      entries.push({date: new Date().toLocaleString(), text});
+      localStorage.setItem('developerDiary', JSON.stringify(entries));
+      textarea.value = '';
+      loadDiary();
+    });
+
+    window.addEventListener('load', loadDiary);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create an index page for recording developer diary
- store diary entries in browser localStorage
- add simple textarea and button to append entries

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856724457a083229954c21fbd1d38b0